### PR TITLE
Added support for boolean values and a fallback

### DIFF
--- a/pdo-debug.php
+++ b/pdo-debug.php
@@ -51,7 +51,11 @@ class PdoDebugger
                 $values[] = implode(',', $value);
             } elseif (is_null($value)) {
                 $values[] = 'NULL';
-            }
+            } elseif (is_bool($value)) {
+				$values[] = strval($value);
+			} else {
+				$values[] = strval($value);
+			}
         }
         if ($isNamedMarkers) {
             return preg_replace($keys, $values, $raw_sql);

--- a/pdo-debug.php
+++ b/pdo-debug.php
@@ -52,10 +52,10 @@ class PdoDebugger
             } elseif (is_null($value)) {
                 $values[] = 'NULL';
             } elseif (is_bool($value)) {
-				$values[] = strval($value);
-			} else {
-				$values[] = strval($value);
-			}
+                $values[] = strval($value);
+            } else {
+                $values[] = strval($value);
+            }
         }
         if ($isNamedMarkers) {
             return preg_replace($keys, $values, $raw_sql);


### PR DESCRIPTION
When the value was boolean type, the script has omitted it, which lead to different counts of items in 'keys' and 'values' arrays, which therefore lead to malfuction. I have also added the last 'else' as a fallback for the case when every other condition fails.

The other commit just converted tabs to spaces.